### PR TITLE
PlatformConfig: Build and add system_ext super partition

### DIFF
--- a/PlatformConfig.mk
+++ b/PlatformConfig.mk
@@ -54,6 +54,10 @@ BOARD_PRODUCTIMAGE_FILE_SYSTEM_TYPE := ext4
 BOARD_PRODUCTIMAGE_JOURNAL_SIZE := 0
 BOARD_PRODUCTIMAGE_EXTFS_INODE_COUNT := 4096
 
+# Build system_ext image
+TARGET_COPY_OUT_SYSTEM_EXT := system_ext
+BOARD_SYSTEM_EXTIMAGE_FILE_SYSTEM_TYPE := ext4
+
 # This platform has a metadata partition: declare this
 # to create a mount point for it
 BOARD_USES_METADATA_PARTITION := true

--- a/rootdir/vendor/etc/fstab.sagami
+++ b/rootdir/vendor/etc/fstab.sagami
@@ -4,6 +4,7 @@
 
 # Logical Partitions
 system                                     /system                 ext4    ro,barrier=1,discard                                                  wait,slotselect,avb=vbmeta_system,logical,first_stage_mount,avb_keys=/avb/r-gsi.avbpubkey:/avb/s-gsi.avbpubkey
+system_ext                                 /system_ext             ext4    ro,barrier=1,discard                                                  wait,slotselect,avb=vbmeta_system,logical,first_stage_mount
 product                                    /product                ext4    ro,barrier=1,discard                                                  wait,slotselect,avb=vbmeta_system,logical,first_stage_mount
 vendor                                     /vendor                 ext4    ro,barrier=1,discard                                                  wait,slotselect,avb,logical,first_stage_mount
 


### PR DESCRIPTION
Keep Sagami in sync with other dynamic partition devices
we have and enable system_ext building of image and
add it to fstab