### PR TITLE
platform.mk: Remove external modem properties

### DIFF
--- a/platform.mk
+++ b/platform.mk
@@ -417,10 +417,6 @@ PRODUCT_PROPERTY_OVERRIDES += \
     ro.surface_flinger.use_color_management=true \
     ro.surface_flinger.wcg_composition_dataspace=143261696
 
-# External modem
-PRODUCT_PROPERTY_OVERRIDES += \
-    persist.vendor.mdm_helper.fail_action=cold_reset
-
 # Gatekeeper
 PRODUCT_PROPERTY_OVERRIDES += \
     vendor.gatekeeper.disable_spu=true


### PR DESCRIPTION
The modem on SM8350 is internal, we don't need the mdm properties here.