### PR TITLE
[R/S] PlatformConfig: Embed recovery in the bootimage

### DIFF
--- a/PlatformConfig.mk
+++ b/PlatformConfig.mk
@@ -69,12 +69,8 @@ BOARD_AVB_VBMETA_SYSTEM_ALGORITHM ?= SHA256_RSA2048
 BOARD_AVB_VBMETA_SYSTEM_ROLLBACK_INDEX := $(PLATFORM_SECURITY_PATCH_TIMESTAMP)
 BOARD_AVB_VBMETA_SYSTEM_ROLLBACK_INDEX_LOCATION := 1
 
-# This target has recovery partitions and bootloader
-# will not set the skip_initramfs cmdline bootparam,
-# so if we turn on recovery as boot, we always end up
-# booting to recovery. Nice!
-TARGET_NO_RECOVERY := false
-BOARD_USES_RECOVERY_AS_BOOT := false
+TARGET_NO_RECOVERY := true
+BOARD_USES_RECOVERY_AS_BOOT := true
 
 # DTBO partition definitions
 TARGET_NEEDS_DTBOIMAGE ?= true

--- a/platform.mk
+++ b/platform.mk
@@ -90,10 +90,6 @@ NUM_FRAMEBUFFER_SURFACE_BUFFERS := 2
 # Lights HAL: Backlight
 TARGET_USES_SDE := true
 
-# Force building a boot image.
-# This needs to be set explicitly since Android R
-PRODUCT_BUILD_BOOT_IMAGE := true
-
 # A/B support
 AB_OTA_UPDATER := true
 PRODUCT_SHIPPING_API_LEVEL := 27
@@ -123,7 +119,6 @@ AB_OTA_PARTITIONS += \
     dtbo \
     product \
     system \
-    recovery \
     vendor \
     vbmeta \
     vbmeta_system


### PR DESCRIPTION
Sagami does not ship with a separate recovery partition (this is a copy-paste remnant from Edo) but instead is back to the good old recovery ramdisk embedded in the boot partition.

We also remove `PRODUCT_BUILD_BOOT_IMAGE` which should not be set when also building a recovery+root image as boot:

    build/make/core/board_config.mk:391: warning: *** PRODUCT_BUILD_BOOT_IMAGE is true, but so is BOARD_USES_RECOVERY_AS_BOOT.
    build/make/core/board_config.mk:392: warning: *** Skipping building boot image.

Fortunately this is just a bogus error message, and a working boot.img is created either way.
