### PR TITLE
[R/S] rootdir: Don't set LOCAL_MODULE_STEM when identical to LOCAL_MODULE

### DIFF
--- a/rootdir/Android.mk
+++ b/rootdir/Android.mk
@@ -4,7 +4,6 @@ include $(CLEAR_VARS)
 LOCAL_MODULE := fstab.$(TARGET_DEVICE)
 LOCAL_SRC_FILES := vendor/etc/fstab.sagami
 LOCAL_MODULE_TAGS := optional
-LOCAL_MODULE_STEM := fstab.$(TARGET_DEVICE)
 LOCAL_MODULE_CLASS := ETC
 LOCAL_MODULE_PATH := $(TARGET_OUT_VENDOR)/etc
 include $(BUILD_PREBUILT)
@@ -22,7 +21,6 @@ include $(CLEAR_VARS)
 LOCAL_MODULE := init.sagami
 LOCAL_SRC_FILES := vendor/etc/init/init.sagami.rc
 LOCAL_MODULE_TAGS := optional
-LOCAL_MODULE_STEM := init.sagami
 LOCAL_MODULE_SUFFIX := .rc
 LOCAL_MODULE_CLASS := ETC
 LOCAL_MODULE_PATH := $(TARGET_OUT_VENDOR)/etc/init
@@ -32,7 +30,6 @@ include $(CLEAR_VARS)
 LOCAL_MODULE := init.sagami.pwr
 LOCAL_SRC_FILES := vendor/etc/init/init.sagami.pwr.rc
 LOCAL_MODULE_TAGS := optional
-LOCAL_MODULE_STEM := init.sagami.pwr
 LOCAL_MODULE_SUFFIX := .rc
 LOCAL_MODULE_CLASS := ETC
 LOCAL_MODULE_PATH := $(TARGET_OUT_VENDOR)/etc/init
@@ -42,7 +39,6 @@ include $(CLEAR_VARS)
 LOCAL_MODULE := ueventd
 LOCAL_SRC_FILES := vendor/ueventd.rc
 LOCAL_MODULE_TAGS := optional
-LOCAL_MODULE_STEM := ueventd
 LOCAL_MODULE_SUFFIX := .rc
 LOCAL_MODULE_CLASS := ETC
 LOCAL_MODULE_PATH := $(TARGET_OUT_VENDOR)
@@ -53,7 +49,6 @@ include $(CLEAR_VARS)
 LOCAL_MODULE := hals.conf
 LOCAL_SRC_FILES := vendor/etc/sensors/hals.conf
 LOCAL_MODULE_TAGS := optional
-LOCAL_MODULE_STEM := hals.conf
 LOCAL_MODULE_SUFFIX :=
 LOCAL_MODULE_CLASS := ETC
 LOCAL_MODULE_PATH := $(TARGET_OUT_VENDOR)/etc/sensors
@@ -64,7 +59,6 @@ include $(CLEAR_VARS)
 LOCAL_MODULE := sns_reg_config
 LOCAL_SRC_FILES := vendor/etc/sensors/sns_reg_config
 LOCAL_MODULE_TAGS := optional
-LOCAL_MODULE_STEM := sns_reg_config
 LOCAL_MODULE_SUFFIX :=
 LOCAL_MODULE_CLASS := ETC
 LOCAL_MODULE_PATH := $(TARGET_OUT_VENDOR)/etc/sensors


### PR DESCRIPTION
If the target name of a "prebuilt" file to be copied is equal to the name of the module, there is no need to repeat this name in the STEM variable - even if the source file has a different name.
