### PR TITLE
platform: Build memtrack for `default` instead of `sm8350`

### DIFF
--- a/platform.mk
+++ b/platform.mk
@@ -237,7 +237,7 @@ PRODUCT_PACKAGES += \
     copybit.sm8350 \
     gralloc.sm8350 \
     hwcomposer.sm8350 \
-    memtrack.sm8350
+    memtrack.default
 
 # GPS
 PRODUCT_PACKAGES += \


### PR DESCRIPTION
`memtrack` moved to a BluePrint file and CAF is not pushing the platform in the libhardware module name anymore, simplifying things.  We must of course update it here to make sure the lib ends up in the build.
