### PR TITLE
Configure Sagami for GKI and vendor_boot

### DIFF
--- a/PlatformConfig.mk
+++ b/PlatformConfig.mk
@@ -70,7 +70,22 @@ BOARD_AVB_VBMETA_SYSTEM_ROLLBACK_INDEX := $(PLATFORM_SECURITY_PATCH_TIMESTAMP)
 BOARD_AVB_VBMETA_SYSTEM_ROLLBACK_INDEX_LOCATION := 1
 
 TARGET_NO_RECOVERY := true
-BOARD_USES_RECOVERY_AS_BOOT := true
+
+# https://source.android.com/devices/bootloader/partitions/generic-boot#combinations, "Launch device without recovery partition":
+BOARD_USES_RECOVERY_AS_BOOT :=
+BOARD_USES_GENERIC_KERNEL_IMAGE := true
+BOARD_MOVE_RECOVERY_RESOURCES_TO_VENDOR_BOOT := true
+BOARD_MOVE_GSI_AVB_KEYS_TO_VENDOR_BOOT := true
+
+# https://source.android.com/devices/bootloader/partitions/vendor-boot-partitions#build-support
+# >= 3 is required for (and turns on) PRODUCT_BUILD_VENDOR_BOOT_IMAGE
+BOARD_BOOT_HEADER_VERSION := 3
+BOARD_RAMDISK_USE_LZ4 := true
+# AOSP does not propagate the header version
+BOARD_MKBOOTIMG_ARGS += --header_version $(BOARD_BOOT_HEADER_VERSION)
+
+# Build vendor_boot with `--dtb $(PRODUCT_OUT)/dtb.img` (generated from BOARD_PREBUILT_DTBIMAGE_DIR in KernelConfig.mk)
+BOARD_INCLUDE_DTB_IN_BOOTIMG := true
 
 # DTBO partition definitions
 TARGET_NEEDS_DTBOIMAGE ?= true

--- a/platform.mk
+++ b/platform.mk
@@ -119,9 +119,10 @@ AB_OTA_PARTITIONS += \
     dtbo \
     product \
     system \
-    vendor \
     vbmeta \
-    vbmeta_system
+    vbmeta_system \
+    vendor \
+    vendor_boot
 
 # Dynamic Partitions: build fastbootd
 PRODUCT_PACKAGES += \

--- a/rootdir/Android.mk
+++ b/rootdir/Android.mk
@@ -14,7 +14,7 @@ LOCAL_SRC_FILES := vendor/etc/fstab.sagami
 LOCAL_MODULE_TAGS := optional
 LOCAL_MODULE_STEM := fstab.$(TARGET_DEVICE)
 LOCAL_MODULE_CLASS := ETC
-LOCAL_MODULE_PATH := $(TARGET_RECOVERY_ROOT_OUT)/first_stage_ramdisk
+LOCAL_MODULE_PATH := $(TARGET_VENDOR_RAMDISK_OUT)/first_stage_ramdisk
 include $(BUILD_PREBUILT)
 
 include $(CLEAR_VARS)


### PR DESCRIPTION
Thus far we've been using a regular compressed kernel with appended DTB in our bootimage, but Sagami realistically supports GKI/vendor_boot.  This partition must be wiped for this "workaround" to work.

As such it is easier and more future-proof to just configure the vendor_boot partition, allowing the use of `fastboot flashall` out of the box without any manual partition erasing.

AOSP prefers to have the appended DTB in vendor_boot, and device-specific Device-Tree configuration in a seperate DTBO image as we've come accustomed to on many prior platforms.  The dtb files are provided by our `KernelConfig.mk` through `BOARD_PREBUILT_DTBIMAGE_DIR`.

All the valid combinations of configuration parameters are listed on the AOSP website, and Sagami devices are considered released with Android 12 and vendor_boot, have an A/B partition layout, and have no separate recovery image (ie. it has a single ramdisk - that is overlaid by the vendor_boot ramdisk - containing the recovery and a separate folder to start the boot from - until mounting `/system` and proceeding from there [1]).  An overview of the necessary configuration parameters is listed at [2] and [3], and also documented in-line in `PlatformConfig.mk`.

Finally, the partition is included in the set of OTA partitions.

Note that the GKI APEX (`com.android.gki.kmi_5_4_android12_0`) is omitted as we do not ship with a clean generic kernel yet; this may be considered over time assuming we can extract all kernel changes to sane kernel modules and include them on `vendor_boot`.

[1]: https://source.android.com/devices/bootloader/partitions/generic-boot#architecture [2]: https://source.android.com/devices/bootloader/partitions/generic-boot#combinations [3]: https://source.android.com/devices/bootloader/partitions/vendor-boot-partitions#build-support
