### PR TITLE
platform: Drop hvdcp_opti initrc

### DIFF
--- a/platform.mk
+++ b/platform.mk
@@ -218,10 +218,6 @@ PRODUCT_PACKAGES += \
     init.sagami.pwr \
     ueventd
 
-# HVDCP init
-PRODUCT_PACKAGES += \
-    hvdcp_opti.rc
-
 # Audio init
 PRODUCT_PACKAGES += \
     audiopd.rc


### PR DESCRIPTION
Sagami on stock does not ship with hvdcp_opti, and errors out when this blob on odm (likely an accidental remnant from Edo) is attempted to be started.
