### PR TITLE
[s-mr1][URGENT] PlatformConfig: Remove msm_drm.blhack_dsi_display0 cmdline

### DIFF
--- a/PlatformConfig.mk
+++ b/PlatformConfig.mk
@@ -31,7 +31,6 @@ BOARD_KERNEL_CMDLINE += lpm_levels.sleep_disabled=1
 BOARD_KERNEL_CMDLINE += androidboot.bootdevice=1d84000.ufshc
 BOARD_KERNEL_CMDLINE += swiotlb=2048
 BOARD_KERNEL_CMDLINE += service_locator.enable=1
-BOARD_KERNEL_CMDLINE += msm_drm.blhack_dsi_display0=dsi_panel_somc_sagami_cmd:config0
 BOARD_KERNEL_CMDLINE += console=null
 
 # Serial console


### PR DESCRIPTION
The msm_drm.blhack_dsi_display0 cmdline hack should only be used if the
bootloader does not set the value for the msm_drm.dsi_display0 cmdline
to be the display panel node name or sets it incorrectly (sets its label
name instead of the actual node name for example). In our case, the Sagami
platform bootloader sets the correct value of the msm_drm.dsi_display0
cmdline.

By having this useless hack we run the risk of having a broken display
panel due to its misconfiguration, hence removing this cmdline property
to avoid this behavior.

Signed-off-by: Pavel Dubrova <pashadubrova@gmail.com>