### PR TITLE
overlay/Settings: Enable (forced) peak refresh rate setting for 120Hz

### DIFF
--- a/overlay/packages/apps/Settings/res/values/config.xml
+++ b/overlay/packages/apps/Settings/res/values/config.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright (C) 2007 The Android Open Source Project
+
+     Licensed under the Apache License, Version 2.0 (the "License");
+     you may not use this file except in compliance with the License.
+     You may obtain a copy of the License at
+
+          http://www.apache.org/licenses/LICENSE-2.0
+
+     Unless required by applicable law or agreed to in writing, software
+     distributed under the License is distributed on an "AS IS" BASIS,
+     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     See the License for the specific language governing permissions and
+     limitations under the License.
+-->
+
+<resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
+    <!-- Whether to show Smooth Display feature in Settings Options -->
+    <bool name="config_show_smooth_display">true</bool>
+</resources>

--- a/overlay/packages/apps/Settings/res/values/strings.xml
+++ b/overlay/packages/apps/Settings/res/values/strings.xml
@@ -18,4 +18,6 @@
     <!-- Message shown in fingerprint enrollment dialog to locate the sensor -->
     <string name="security_settings_fingerprint_enroll_find_sensor_message">
         Locate the fingerprint sensor on the side of your phone.</string>
+
+    <string name="peak_refresh_rate_summary">Automatically raises the refresh rate from 60 to 120 Hz for some content. Increases battery usage.</string>
 </resources>


### PR DESCRIPTION
Enabling `config_show_smooth_display` unlocks two options: a "Smooth Display" settings toggle that - according to the settings text - bumps to 120 Hz for **some content**, and a "Force peak refresh rate" in developer settings that actually runs the screen at 120Hz all the time, resulting in buttery smooth UI.
