### PR TITLE
Bluetooth Fixes[#1] : platform: Move QCOM Bluetooth packages to common

### DIFF
--- a/platform.mk
+++ b/platform.mk
@@ -343,10 +343,6 @@ PRODUCT_PROPERTY_OVERRIDES += \
     ro.hardware.camera=qcom
 
 # QCOM Bluetooth
-PRODUCT_PACKAGES += \
-    android.hardware.bluetooth@1.0-impl-qti \
-    android.hardware.bluetooth@1.0-service-qti
-
 PRODUCT_PROPERTY_OVERRIDES += \
     persist.vendor.qcom.bluetooth.soc=hastings
 


### PR DESCRIPTION
These exists on all our currently supported platforms